### PR TITLE
fix: should use claimedOrigin in metadata

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/contexts/ClientContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/ClientContext.tsx
@@ -291,6 +291,10 @@ export function ClientContextProvider({
         logger: DEFAULT_LOGGER,
         relayUrl: relayerRegion,
         projectId: DEFAULT_PROJECT_ID,
+        metadata: {
+          ...DEFAULT_APP_METADATA,
+          url: claimedOrigin,
+        },
       });
 
       setClient(_client);


### PR DESCRIPTION
Should use the `claimedOrigin` which set from OriginSimulationDropdown in metadata, testing verify API depends on this