### PR TITLE
feat: close wallet tab after request modal is closed

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/wc.tsx
@@ -35,12 +35,11 @@ export default function DeepLinkPairingPage() {
   }, [state.view])
 
   useEffect(() => {
-    if (requestId) {
-      ModalStore.open('LoadingModal', { loadingMessage })
-    }
-
-    if (uri) {
-      ModalStore.open('LoadingModal', { loadingMessage })
+    if (uri || requestId) {
+      ModalStore.open('LoadingModal', { loadingMessage }, () => {
+        console.log('Modal closed')
+        window.close()
+      })
     }
   }, [uri, requestId, loadingMessage])
 

--- a/advanced/wallets/react-wallet-v2/src/store/ModalStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/ModalStore.ts
@@ -1,6 +1,5 @@
 import { SessionTypes, SignClientTypes } from '@walletconnect/types'
-import { WalletKitTypes } from '@reown/walletkit'
-import { proxy } from 'valtio'
+import { proxy, subscribe } from 'valtio'
 
 /**
  * Types
@@ -52,10 +51,18 @@ const state = proxy<State>({
 const ModalStore = {
   state,
 
-  open(view: State['view'], data: State['data']) {
+  open(view: State['view'], data: State['data'], onClose?: () => void) {
     state.view = view
     state.data = data
     state.open = true
+    if (!onClose) return
+    const unsubscribe = subscribe(state, () => {
+      if (!state.open) {
+        console.log('ModalStore: Closing modal')
+        unsubscribe()
+        onClose?.()
+      }
+    })
   },
 
   close() {


### PR DESCRIPTION
The wallet now closes automatically after responding to a request from a deeplink. This removes tab clutter as apps open the wallet in a new new tab on every request  

https://www.notion.so/walletconnect/Engineering-1405a07b0a424104b65d9df0c2e6648e?p=1a53a661771e8077bf2dc67e0f2020b2&pm=s