### PR TITLE
chore: copy verification gas limit

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
@@ -326,6 +326,7 @@ export abstract class SmartAccountLib implements EIP155Wallet {
     const userOpWithStubData: UserOperation<'v0.7'> = {
       ...userOpPreStubData,
       ...paymasterStubData,
+      verificationGasLimit: paymasterStubData.paymasterVerificationGasLimit,
       signature: '0x'
     }
 

--- a/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/smart-accounts/SmartAccountLib.ts
@@ -326,7 +326,7 @@ export abstract class SmartAccountLib implements EIP155Wallet {
     const userOpWithStubData: UserOperation<'v0.7'> = {
       ...userOpPreStubData,
       ...paymasterStubData,
-      verificationGasLimit: paymasterStubData.paymasterVerificationGasLimit,
+      verificationGasLimit: paymasterStubData.paymasterVerificationGasLimit ?? 0n,
       signature: '0x'
     }
 


### PR DESCRIPTION
fix bug with user op gas estimation during paymaster sponsored ops