### PR TITLE
fix: support decimals for tokens

### DIFF
--- a/advanced/dapps/chain-abstraction-demo/app/hooks/useGiftDonut.tsx
+++ b/advanced/dapps/chain-abstraction-demo/app/hooks/useGiftDonut.tsx
@@ -84,8 +84,7 @@ export default function useGiftDonut() {
       const contract = getTokenContract(token, chainId);
       
       // Calculate token amount using token's decimals
-      const tokenAmount = donutCount * 1 * 10 ** token.decimals;
-
+      const tokenAmount = donutCount * 10 ** token.decimals;
       // Start tracking elapsed time
       updateInterval = setInterval(() => {
         updateToast(toastId, "waiting-approval", {

--- a/advanced/dapps/chain-abstraction-demo/app/hooks/useGiftDonut.tsx
+++ b/advanced/dapps/chain-abstraction-demo/app/hooks/useGiftDonut.tsx
@@ -82,7 +82,9 @@ export default function useGiftDonut() {
 
       // Get token contract
       const contract = getTokenContract(token, chainId);
-      const tokenAmount = donutCount * 1 * 10 ** 6;
+      
+      // Calculate token amount using token's decimals
+      const tokenAmount = donutCount * 1 * 10 ** token.decimals;
 
       // Start tracking elapsed time
       updateInterval = setInterval(() => {

--- a/advanced/dapps/chain-abstraction-demo/data/EIP155Data.ts
+++ b/advanced/dapps/chain-abstraction-demo/data/EIP155Data.ts
@@ -17,6 +17,7 @@ export interface Token {
   icon: string;
   address: string;
   supportedChainIds: number[];
+  decimals: number;
 }
 
 export const supportedNetworks: Network[] = [
@@ -46,18 +47,21 @@ export const supportedTokens: Token[] = [
     icon: "/token-images/USDC.png",
     address: "0x1",
     supportedChainIds: [arbitrum.id, base.id, optimism.id],
+    decimals: 6
   },
   {
     name: "USDT",
     icon: "/token-images/USDT.png",
     address: "0x2",
     supportedChainIds: [arbitrum.id, optimism.id],
+    decimals: 6
   },
   {
     name: "USDS",
     icon: "/token-images/USDS(DAI).png",
     address: "0x3",
     supportedChainIds: [base.id],
+    decimals: 18
   },
 ];
 

--- a/advanced/dapps/chain-abstraction-demo/utils/BalanceFetcherUtil.ts
+++ b/advanced/dapps/chain-abstraction-demo/utils/BalanceFetcherUtil.ts
@@ -1,4 +1,4 @@
-import { usdcTokenAddresses, usdtTokenAddresses } from "@/consts/tokens";
+import { usdcTokenAddresses, usdtTokenAddresses, usdsTokenAddresses } from "@/consts/tokens";
 import { createPublicClient, erc20Abi, Hex, http, PublicClient } from "viem";
 import { formatBalance } from "@/utils/FormatterUtil";
 import { getChain } from "@/utils/NetworksUtil";
@@ -111,6 +111,16 @@ export async function fetchFallbackBalances(
         symbol: "USDT",
         decimals: 6,
         address: usdtAddress,
+      });
+    }
+
+    // Add USDS if supported
+    const usdsAddress = usdsTokenAddresses[currentChainId];
+    if (usdsAddress) {
+      supportedTokens.push({
+        symbol: "USDS",
+        decimals: 18,
+        address: usdsAddress,
       });
     }
 


### PR DESCRIPTION
Removed magic number to use decimals added into the token structure this way the routes work for all tokens (in this case USDs has 18)

https://github.com/user-attachments/assets/860e66c9-3b12-432c-9de1-d17354fec023

