### PR TITLE
chore: sets wallet logger to trace

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
@@ -6,7 +6,7 @@ export async function createWalletKit(relayerRegionURL: string) {
   const core = new Core({
     projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
     relayUrl: relayerRegionURL ?? process.env.NEXT_PUBLIC_RELAY_URL,
-    logger: 'warn'
+    logger: 'trace'
   })
   walletkit = await WalletKit.init({
     core,


### PR DESCRIPTION
the logger was updated to `warn` in https://github.com/reown-com/web-examples/pull/880 which broke Appkit canary due to its reliance on trace logs