### PR TITLE
chore: update Solana preflight commitment to confirmed

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/SolanaLib.ts
@@ -85,7 +85,7 @@ export default class SolanaLib {
 
     const signature = await connection.sendTransaction(transaction, {
       maxRetries: 3,
-      preflightCommitment: 'recent',
+      preflightCommitment: 'confirmed',
       ...params.options
     })
 


### PR DESCRIPTION
RPCs are dropping support for `recent` as its legacy. Updating preflight commitment for transaction sending to `confirmed`