### PR TITLE
chore: show unbounceable address, use payload if available

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
@@ -101,7 +101,7 @@ export default class TonLib {
 
     const dataToSign = this.getToSign(params)
     const signature = sign(dataToSign, this.keypair.secretKey as unknown as Buffer)
-    const addressStr = this.wallet.address.toString({ bounceable: false })
+    const addressStr = this.getAddress()
 
     const result = {
       signature: signature.toString('base64'),

--- a/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
@@ -47,7 +47,7 @@ export default class TonLib {
   }
 
   public async getAddress() {
-    return this.wallet.address.toString()
+    return this.wallet.address.toString({ bounceable: false })
   }
 
   public getSecretKey() {
@@ -76,7 +76,7 @@ export default class TonLib {
       return internal({
         to: Address.parse(m.address),
         value: amountBigInt,
-        body: 'Test transfer from ton WalletConnect'
+        body: m.payload ?? 'Test transfer from ton WalletConnect'
       })
     })
 
@@ -101,7 +101,7 @@ export default class TonLib {
 
     const dataToSign = this.getToSign(params)
     const signature = sign(dataToSign, this.keypair.secretKey as unknown as Buffer)
-    const addressStr = this.wallet.address.toString()
+    const addressStr = this.wallet.address.toString({ bounceable: false })
 
     const result = {
       signature: signature.toString('base64'),

--- a/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TonLib.ts
@@ -101,7 +101,7 @@ export default class TonLib {
 
     const dataToSign = this.getToSign(params)
     const signature = sign(dataToSign, this.keypair.secretKey as unknown as Buffer)
-    const addressStr = this.getAddress()
+    const addressStr = await this.getAddress()
 
     const result = {
       signature: signature.toString('base64'),
@@ -125,6 +125,7 @@ export default class TonLib {
     } catch (e) {
       console.warn('TON signData verification failed to run', e)
     }
+
     return result
   }
 


### PR DESCRIPTION
## Summary
- Shows un-bounceable address in TON
- Uses payload in `sendMessage` when available 

<img width="758" height="538" alt="image" src="https://github.com/user-attachments/assets/c0654ae1-0e95-44f4-bf10-6e653a34cc33" />
