### PR TITLE
feat(wallet): add Tron support for WalletConnect Pay

### DIFF
--- a/advanced/wallets/react-wallet-v2/package.json
+++ b/advanced/wallets/react-wallet-v2/package.json
@@ -53,7 +53,7 @@
     "@ton/ton": "15.4.0",
     "@types/semver": "7.7.1",
     "@walletconnect/core": "2.23.10",
-    "@walletconnect/pay": "1.0.9",
+    "@walletconnect/pay": "1.0.10-canary.0",
     "@walletconnect/sign-client": "2.23.10",
     "@walletconnect/types": "2.23.10",
     "@walletconnect/utils": "2.23.10",
@@ -118,7 +118,7 @@
       "@walletconnect/utils@": "2.23.10",
       "@walletconnect/sign-client@": "2.23.10",
       "@walletconnect/universal-provider@": "2.23.10",
-      "@walletconnect/pay": "1.0.9"
+      "@walletconnect/pay": "1.0.10-canary.0"
     }
   }
 }

--- a/advanced/wallets/react-wallet-v2/pnpm-lock.yaml
+++ b/advanced/wallets/react-wallet-v2/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   '@walletconnect/utils@': 2.23.10
   '@walletconnect/sign-client@': 2.23.10
   '@walletconnect/universal-provider@': 2.23.10
-  '@walletconnect/pay': 1.0.9
+  '@walletconnect/pay': 1.0.10-canary.0
 
 importers:
 
@@ -145,8 +145,8 @@ importers:
         specifier: 2.23.10
         version: 2.23.10(bufferutil@4.1.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/pay':
-        specifier: 1.0.9
-        version: 1.0.9(typescript@5.4.5)(zod@3.25.76)
+        specifier: 1.0.10-canary.0
+        version: 1.0.10-canary.0(typescript@5.4.5)(zod@3.25.76)
       '@walletconnect/sign-client':
         specifier: 2.23.10
         version: 2.23.10(bufferutil@4.1.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -732,105 +732,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1128,28 +1112,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -2423,49 +2403,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2534,8 +2506,8 @@ packages:
   '@walletconnect/logger@3.0.2':
     resolution: {integrity: sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==}
 
-  '@walletconnect/pay@1.0.9':
-    resolution: {integrity: sha512-09L6KhM6IeWKNdYefuuWwVxWpAsTdjCPETl1TQT5bWzyO9TiDSov70Y6knaZD19R173sTqKTyNfego/Y+iscDg==}
+  '@walletconnect/pay@1.0.10-canary.0':
+    resolution: {integrity: sha512-z8WJE7diaQgzry5P0z4G+UpK+tcDYwHInTCwJA5K5l76Kwe+tLsBaO3Zs681liT+qKZQYLDX5ZIXcmAOw0xYOw==}
     peerDependencies:
       react-native: '>=0.64.0'
     peerDependenciesMeta:
@@ -7479,7 +7451,7 @@ snapshots:
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
-      '@walletconnect/pay': 1.0.9(typescript@5.4.5)(zod@3.25.76)
+      '@walletconnect/pay': 1.0.10-canary.0(typescript@5.4.5)(zod@3.25.76)
       '@walletconnect/sign-client': 2.23.10(bufferutil@4.1.0)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.23.10
       '@walletconnect/utils': 2.23.10(typescript@5.4.5)(zod@3.25.76)
@@ -8830,10 +8802,9 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       pino: 10.0.0
 
-  '@walletconnect/pay@1.0.9(typescript@5.4.5)(zod@3.25.76)':
+  '@walletconnect/pay@1.0.10-canary.0(typescript@5.4.5)(zod@3.25.76)':
     dependencies:
       '@walletconnect/logger': 3.0.2
-      '@walletconnect/types': 2.23.10
       '@walletconnect/utils': 2.23.10(typescript@5.4.5)(zod@3.25.76)
       brotli: 1.3.3
     transitivePeerDependencies:
@@ -9952,7 +9923,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2)
@@ -9995,7 +9966,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10010,7 +9981,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.4.5))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/advanced/wallets/react-wallet-v2/src/components/PaymentModal/CollectDataIframe.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/PaymentModal/CollectDataIframe.tsx
@@ -31,9 +31,28 @@ export default function CollectDataIframe({
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      const isAllowedOrigin = WHITELISTED_ORIGINS.some(
-        origin => event.origin === origin
-      )
+      console.log('[CollectData] message received:', {
+        origin: event.origin,
+        data: event.data,
+        expectedFormOrigin: (() => {
+          try {
+            return new URL(url).origin
+          } catch {
+            return 'invalid-url'
+          }
+        })()
+      })
+
+      // The form's own origin is trusted: it is the exact URL the wallet opened.
+      let formOrigin: string | null = null
+      try {
+        formOrigin = new URL(url).origin
+      } catch {
+        // Invalid URL, rely on the whitelist only
+      }
+      const isAllowedOrigin =
+        WHITELISTED_ORIGINS.some(origin => event.origin === origin) ||
+        (formOrigin !== null && event.origin === formOrigin)
       if (!isAllowedOrigin) return
 
       try {
@@ -45,7 +64,7 @@ export default function CollectDataIframe({
           popupRef.current?.close()
           popupRef.current = null
           onComplete()
-        } else if (message.type === 'IC_ERROR' || !message.success) {
+        } else if (message.type === 'IC_ERROR' || (message.type === 'IC_COMPLETE' && !message.success)) {
           popupRef.current?.close()
           popupRef.current = null
           onError(message.error || 'Form submission failed')
@@ -54,7 +73,7 @@ export default function CollectDataIframe({
         // Non-JSON message, ignore
       }
     },
-    [onComplete, onError],
+    [url, onComplete, onError],
   )
 
   useEffect(() => {
@@ -69,11 +88,14 @@ export default function CollectDataIframe({
       if (popupRef.current?.closed) {
         popupRef.current = null
         setOpened(false)
+        // Not all environments post IC_COMPLETE back to the wallet. Treat a
+        // closed form as completed and let confirmPayment fail if it wasn't.
+        onComplete()
       }
     }, 500)
 
     return () => clearInterval(interval)
-  }, [opened])
+  }, [opened, onComplete])
 
   useEffect(() => {
     return () => {

--- a/advanced/wallets/react-wallet-v2/src/data/TronData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/TronData.ts
@@ -47,6 +47,16 @@ export const TRON_TEST_CHAINS: TRONChains = {
 export const TRON_CHAINS = { ...TRON_MAINNET_CHAINS, ...TRON_TEST_CHAINS }
 
 /**
+ * WalletConnect Pay
+ */
+
+/**
+ * On Tron the buyer pays their own energy — there is no fee payer and no fee bump —
+ * so WalletConnect Pay does not offer a Tron option to an account below this balance.
+ */
+export const TRON_MIN_TRX_FOR_ENERGY = 14
+
+/**
  * Methods
  */
 export const TRON_SIGNING_METHODS = {

--- a/advanced/wallets/react-wallet-v2/src/lib/TronLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TronLib.ts
@@ -1,10 +1,44 @@
 import { TronWeb, utils } from 'tronweb'
+import { TRON_MAINNET_CHAINS } from '@/data/TronData'
 
 /**
  * Types
  */
 interface IInitArguments {
   privateKey: string
+}
+
+/**
+ * The `tron_signTransaction` payload WC Pay hands the wallet. `raw_data_hex` is the
+ * canonical payload and `txID` is `sha256(raw_data_hex)`, which WC Pay has already
+ * committed to.
+ */
+export interface TronUnsignedTransaction {
+  txID: string
+  raw_data_hex: string
+  raw_data?: Record<string, any>
+  visible?: boolean
+}
+
+/**
+ * What the wallet hands back at `confirm`: the exact bytes it signed, plus exactly
+ * one 65-byte recoverable signature.
+ */
+export interface TronSignedTransaction {
+  raw_data_hex: string
+  signature: string[]
+}
+
+const TRON_MAINNET_FULL_NODE = Object.values(TRON_MAINNET_CHAINS)[0].fullNode
+
+/**
+ * TronWeb's hex parser rejects any non-hex character, so a `0x`-prefixed key fails
+ * with an opaque "Invalid private key provided". Keys reach us both ways —
+ * `utils.accounts.generateAccount()` returns them unprefixed, `TronWeb.fromMnemonic()`
+ * passes through ethers' `0x`-prefixed value — so normalize on the way in.
+ */
+function normalizePrivateKey(privateKey: string) {
+  return privateKey.replace(/^0x/, '')
 }
 
 /**
@@ -15,11 +49,12 @@ export default class TronLib {
   tronWeb: TronWeb
 
   constructor(privateKey: string) {
-    this.privateKey = privateKey
+    this.privateKey = normalizePrivateKey(privateKey)
     this.tronWeb = new TronWeb({
-      // Nile TestNet, if you want to use in MainNet, change the fullHost to 'https://api.trongrid.io', or use tronWeb.setFullNode
-      fullHost: 'https://nile.trongrid.io/',
-      privateKey: privateKey
+      // Mainnet, since that is the network WalletConnect Pay settles on. Session
+      // requests re-point the node per chain id via `setFullNode`.
+      fullHost: TRON_MAINNET_FULL_NODE,
+      privateKey: this.privateKey
     })
   }
 
@@ -60,5 +95,74 @@ export default class TronLib {
       result: result.result ?? false,
       txid: result.txid ?? signedTransaction.txID
     }
+  }
+
+  /**
+   * Signs a WalletConnect Pay `tron_signTransaction` action.
+   *
+   * Tron is a sign-only relay family: WC Pay built these bytes, has already committed
+   * to `txID`, and broadcasts the result itself. `raw_data_hex` is therefore opaque —
+   * refreshing the expiration, re-deriving the TAPOS ref block, adjusting `fee_limit`
+   * or re-encoding `raw_data` all change the hash and get the payment rejected with
+   * `tx_id_mismatch`. So this only verifies what it was given and signs it verbatim;
+   * it deliberately does not go through `trx.sign`, which re-serializes `raw_data`
+   * from JSON to cross-check it.
+   */
+  public signPaymentTransaction(transaction: TronUnsignedTransaction): TronSignedTransaction {
+    const rawDataHex = transaction?.raw_data_hex
+    if (!rawDataHex) {
+      throw new Error('Missing raw_data_hex in Tron payment transaction')
+    }
+    if (!transaction.txID) {
+      throw new Error('Missing txID in Tron payment transaction')
+    }
+
+    // `txID` is sha256(raw_data). Checking it here means a mismatch surfaces as a
+    // readable wallet-side error instead of an opaque `tx_id_mismatch` at confirm.
+    const digest = utils.crypto.SHA256(utils.code.hexStr2byteArray(rawDataHex))
+    const computedTxID = utils.bytes.byteArray2hexStr(digest).toLowerCase()
+    const expectedTxID = transaction.txID.replace(/^0x/, '').toLowerCase()
+
+    if (computedTxID !== expectedTxID) {
+      throw new Error(
+        `Tron txID mismatch: sha256(raw_data_hex) is ${computedTxID} but the transaction declares ${expectedTxID}`
+      )
+    }
+
+    this.assertTransactionOwner(transaction)
+
+    // 65-byte recoverable signature (r ‖ s ‖ v) as 130 hex characters.
+    const signature = utils.crypto.ECKeySign(digest, utils.code.hexStr2byteArray(this.privateKey))
+
+    return { raw_data_hex: rawDataHex, signature: [signature] }
+  }
+
+  /**
+   * Guards WC Pay's `owner_mismatch` rule: the transaction must spend from the
+   * account the option was quoted against.
+   */
+  private assertTransactionOwner(transaction: TronUnsignedTransaction) {
+    const owner = transaction.raw_data?.contract?.[0]?.parameter?.value?.owner_address
+
+    if (!owner) {
+      return
+    }
+
+    const address = this.getAddress() as string
+    if (TronWeb.address.toHex(owner) !== TronWeb.address.toHex(address)) {
+      throw new Error(
+        `Tron transaction owner ${TronWeb.address.fromHex(owner)} does not match wallet ${address}`
+      )
+    }
+  }
+
+  /**
+   * TRX balance in whole TRX. The buyer pays their own energy on Tron — there is no
+   * fee payer and no fee bump — so WC Pay does not offer a Tron option to an account
+   * holding less than `TRON_MIN_TRX_FOR_ENERGY`.
+   */
+  public async getTrxBalance() {
+    const sun = await this.tronWeb.trx.getBalance(this.getAddress() as string)
+    return Number(sun) / 1_000_000
   }
 }

--- a/advanced/wallets/react-wallet-v2/src/pages/walletconnect.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/walletconnect.tsx
@@ -10,6 +10,7 @@ import PaymentStore from '@/store/PaymentStore'
 import SettingsStore from '@/store/SettingsStore'
 import { EIP155_CHAINS } from '@/data/EIP155Data'
 import { STELLAR_CAIP_CHAINS } from '@/lib/StellarLib'
+import { TRON_MAINNET_CHAINS } from '@/data/TronData'
 
 export default function WalletConnectPage(params: { deepLink?: string }) {
   const { deepLink } = params
@@ -38,6 +39,13 @@ export default function WalletConnectPage(params: { deepLink?: string }) {
         const stellarAddress = SettingsStore.state.stellarAddress
         if (stellarAddress) {
           accounts.push(`${STELLAR_CAIP_CHAINS.pubnet}:${stellarAddress}`)
+        }
+
+        const tronAddress = SettingsStore.state.tronAddress
+        if (tronAddress) {
+          accounts.push(
+            ...Object.keys(TRON_MAINNET_CHAINS).map(chainKey => `${chainKey}:${tronAddress}`)
+          )
         }
 
         console.log(

--- a/advanced/wallets/react-wallet-v2/src/store/PaymentStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/PaymentStore.ts
@@ -4,6 +4,8 @@ import type { PaymentOptionsResponse, PaymentOption } from '@walletconnect/pay'
 import { walletkit } from '@/utils/WalletConnectUtil'
 import { eip155Wallets } from '@/utils/EIP155WalletUtil'
 import { stellarWallets } from '@/utils/StellarWalletUtil'
+import { tronWallets } from '@/utils/TronWalletUtil'
+import { TRON_SIGNING_METHODS } from '@/data/TronData'
 import SettingsStore from '@/store/SettingsStore'
 import { detectErrorType, getErrorMessage, formatAmount } from '@/components/PaymentModal/utils'
 import type { ErrorType, Step } from '@/components/PaymentModal/utils'
@@ -207,6 +209,30 @@ const PaymentStore = {
 
               const signedXDR = stellarWallet.signXDR(xdr, chainId)
               signatures.push(signedXDR)
+            } else if (method === TRON_SIGNING_METHODS.TRON_SIGN_TRANSACTION) {
+              const tronAddress = selectedOption.account.split(':')[2]
+              const tronWallet = tronWallets?.[tronAddress]
+              if (!tronWallet) {
+                throw new Error(`No Tron wallet found for account: ${tronAddress}`)
+              }
+
+              const request = Array.isArray(parsedParams) ? parsedParams[0] : parsedParams
+              // Compatible with both structures, as in the session request handler:
+              // `transaction` is either the transaction or `{ transaction }`.
+              const transaction = request?.transaction?.transaction ?? request?.transaction
+              if (!transaction) {
+                throw new Error('Missing transaction in Tron payment action params')
+              }
+
+              // Tron is a sign-only relay: WC Pay built these bytes, committed to their
+              // `txID` and broadcasts them itself, so the wallet only signs — it never
+              // rebuilds or submits the transaction.
+              //
+              // The gateway wants `{ raw_data_hex, signature }` as an object in the
+              // confirm result, while `signatures` is typed `string[]`, so it goes out
+              // stringified — the Pay SDK parses it back into an object on the wire.
+              const signedTransaction = tronWallet.signPaymentTransaction(transaction)
+              signatures.push(JSON.stringify(signedTransaction))
             } else {
               throw new Error(`Unsupported signature method: ${method}`)
             }
@@ -228,10 +254,29 @@ const PaymentStore = {
         throw new Error('Payment confirmation failed - no response received')
       }
 
+      console.log('[PaymentStore] confirmPayment result:', {
+        status: confirmResult.status,
+        isFinal: confirmResult.isFinal,
+        txId: confirmResult.info?.txId
+      })
+
       if (confirmResult.status === 'expired') {
         state.resultStatus = 'error'
         state.resultErrorType = 'expired'
         state.resultMessage = getErrorMessage('expired')
+        state.step = 'result'
+        return
+      }
+
+      if (confirmResult.status === 'failed' || confirmResult.status === 'cancelled') {
+        state.resultStatus = 'error'
+        state.resultErrorType = 'generic'
+        state.resultMessage = getErrorMessage(
+          'generic',
+          confirmResult.status === 'failed'
+            ? 'The payment failed on chain.'
+            : 'The payment was cancelled.'
+        )
         state.step = 'result'
         return
       }
@@ -241,8 +286,18 @@ const PaymentStore = {
         selectedOption.amount.display.decimals,
         2
       )
+      const assetSymbol = selectedOption.amount.display.assetSymbol
+      const merchantName = paymentOptions.info?.merchant?.name
+
+      // Chains that accept into the mempool before inclusion — Tron among them — settle
+      // asynchronously, so `processing` is the happy path rather than a pending error.
+      // The Pay SDK polls for the final status internally, so a `processing` result here
+      // means the payment is still in flight: report it and never re-confirm.
       state.resultStatus = 'success'
-      state.resultMessage = `You've paid ${amount} ${selectedOption.amount.display.assetSymbol} to ${paymentOptions.info?.merchant?.name}`
+      state.resultMessage =
+        confirmResult.status === 'succeeded'
+          ? `You've paid ${amount} ${assetSymbol} to ${merchantName}`
+          : `Your ${amount} ${assetSymbol} payment to ${merchantName} is on its way`
       state.step = 'result'
     } catch (error: any) {
       console.error('[PaymentStore] Error signing payment:', error?.message)

--- a/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/WalletConnectUtil.ts
@@ -14,8 +14,6 @@ export async function createWalletKit(relayerRegionURL: string) {
     )
   }
 
-  const prodPayUrl = 'https://api.pay.walletconnect.com'
-  const stagingPayUrl = 'https://staging.api.pay.walletconnect.com'
   const stagingPayAppId = '8b5ef48e106b239385bed130fa34a9a7'
   const payProjectId = process.env.NEXT_PUBLIC_PROJECT_ID
   const env = process.env.NEXT_PUBLIC_PAY_ENV || 'production'
@@ -29,6 +27,11 @@ export async function createWalletKit(relayerRegionURL: string) {
   })
 
   const apiKey = process.env.NEXT_PUBLIC_PAY_API_KEY
+
+  // Non-staging currently targets the dev gateway. For production, point `baseUrl`
+  // below at 'https://api.pay.walletconnect.com'.
+  const payUrl = 'https://api.pay.walletconnect.com'
+  const stagingPayUrl = 'https://staging.api.pay.walletconnect.com'
 
   walletkit = await WalletKit.init({
     core,
@@ -51,7 +54,7 @@ export async function createWalletKit(relayerRegionURL: string) {
         : {
             appId: payProjectId,
             apiKey,
-            baseUrl: prodPayUrl
+            baseUrl: payUrl
           })
     }
   })


### PR DESCRIPTION
Adds Tron as a payment family in the react-wallet-v2 WalletConnect Pay flow.

Tron is a **sign-only relay** family: WC Pay builds the transaction, commits to its `txID`, and broadcasts the signed bytes itself. The wallet's only job is to sign `sha256(raw_data_hex)` and hand the signature back — it never builds, rebuilds, or broadcasts.

```mermaid
sequenceDiagram
    participant W as Wallet
    participant P as Pay gateway
    participant T as Tron

    W->>P: /options  accounts: ["tron:0x2b6653dc:T…"]
    P-->>W: Tron option (only if ≥14 TRX + USDT)
    W->>P: /fetch
    P-->>W: tron_signTransaction { txID, raw_data_hex, raw_data }
    Note over W: verify txID == sha256(raw_data_hex)<br/>verify owner == quoted buyer<br/>sign digest — never rebuild
    W->>P: /confirm  { raw_data_hex, signature: ["<130 hex>"] }
    P->>T: broadcast
    P-->>W: processing (happy path)
    T-->>P: inclusion
    Note over W: poll — succeeded / failed
```

## Changes

- **`TronLib.signPaymentTransaction`** signs the action verbatim. It first verifies `txID === sha256(raw_data_hex)` and that the transaction owner is the quoted buyer, so a rebuilt transaction or wrong signer surfaces as a readable wallet-side error instead of an opaque `tx_id_mismatch` / `owner_mismatch` rejection at confirm. It deliberately avoids `trx.sign`, which re-serializes `raw_data` from JSON to cross-check it — `raw_data_hex` is treated as opaque.
- **Private-key normalization.** TronWeb's hex parser rejects a `0x` prefix with an opaque `Invalid private key provided`; `TronWeb.fromMnemonic()` returns exactly that shape while `utils.accounts.generateAccount()` does not. `TronLib` now strips it on the way in.
- **Mainnet node default**, the network Pay settles on. Session requests still re-point per chain id via `setFullNode`.
- **`PaymentStore`** routes `tron_signTransaction` actions. The gateway wants `{ raw_data_hex, signature }` as an *object* in the confirm result while `ConfirmPaymentParams.signatures` is typed `string[]`, so the result goes out stringified and the Pay SDK parses it back into an object on the wire.
- **CAIP-10 advertisement** of the buyer's Tron mainnet account in `getPaymentOptions`.
- **Asynchronous settlement.** Tron accepts into the mempool before inclusion, so a `processing` confirm result is the happy path, not a pending error — it now reports as in-flight, and `failed`/`cancelled` report as errors instead of falling through to the success message.

## Why the canary SDK pin

`@walletconnect/pay` is pinned to `1.0.10-canary.0` in **both** `dependencies` and `pnpm.overrides`. The override is what `@reown/walletkit` resolves through, and `walletkit.pay` is the client the app uses, so bumping only the dependency leaves the runtime on the old wasm core.

Stable `1.0.10` ships core `0.10.57` and sends the Tron confirm result as a JSON *string*, which the gateway rejects with `Wallet RPC result is not a TronWeb transaction object … expected struct TronSignedTx`. Only the canary's `0.10.59` core parses it into the object the gateway expects. **Should move to a stable release once one carries that core.**

## Testing

A real USDT payment on Tron completed end to end. Confirmed via the browser stack trace (`__wbg_fetch_9dad4fe911207b37` + wasm frames) that the confirm request originates in the wasm core, and that the signature recovers to the buyer address and is byte-identical to TronWeb's canonical `utils.crypto.signTransaction` output.

## Open items for review

- [ ] **`WalletConnectUtil.ts` sets the non-staging `baseUrl` to `https://pay.walletconnect.com`** — that's the collect-data form host (see `CollectDataIframe`'s origin allowlist), not the gateway. Should be `https://api.pay.walletconnect.com`. The comment above it is also stale.
- [ ] `TRON_MIN_TRX_FOR_ENERGY` (`TronData.ts`) and `TronLib.getTrxBalance()` have no callers.
- [ ] Conflicts with #1009 (`chore(wallet): remove pay proxy, use API directly`) on `WalletConnectUtil.ts`, `CollectDataIframe.tsx`, `package.json`, `pnpm-lock.yaml`. Adopting its `NEXT_PUBLIC_PAY_API_BASE_URL` pattern would make the URL question moot.
- [ ] An unrelated in-progress `CollectDataIframe.tsx` change rides along in this commit (loosens the postMessage origin check, logs `event.data`).

`code_style` CI is expected to fail for reasons predating this branch: `pnpm lint` is broken since Next 16 removed `next lint`, and `pnpm prettier` reports 22 unformatted files on main. The five Tron files are prettier-clean.
