### PR TITLE
feat: add TRON Shasta testnet support

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/chains/tron.ts
+++ b/advanced/dapps/react-dapp-v2/src/chains/tron.ts
@@ -17,7 +17,7 @@ export const TronChainData: ChainsMap = {
   },
   "0x94a9059e": {
     id: "tron:0x94a9059e",
-    name: "TRON Shasta Testnet",
+    name: "Tron Testnet (Shasta)",
     rpc: [],
     slip44: 195,
     testnet: true,
@@ -37,7 +37,7 @@ export const TronMetadata: NamespaceMetadata = {
   },
   // Tron Shasta Testnet
   "0x94a9059e": {
-    logo: "assets/tron.png",
+    logo: "/assets/tron.png",
     rgb: "183, 62, 49",
   },
 };

--- a/advanced/dapps/react-dapp-v2/src/chains/tron.ts
+++ b/advanced/dapps/react-dapp-v2/src/chains/tron.ts
@@ -15,6 +15,13 @@ export const TronChainData: ChainsMap = {
     slip44: 195,
     testnet: true,
   },
+  "0x94a9059e": {
+    id: "tron:0x94a9059e",
+    name: "TRON Shasta Testnet",
+    rpc: [],
+    slip44: 195,
+    testnet: true,
+  },
 };
 
 export const TronMetadata: NamespaceMetadata = {
@@ -25,6 +32,11 @@ export const TronMetadata: NamespaceMetadata = {
   },
   // Tron Testnet (Nile)
   "0xcd8690dc": {
+    logo: "assets/tron.png",
+    rgb: "183, 62, 49",
+  },
+  // Tron Shasta Testnet
+  "0x94a9059e": {
     logo: "assets/tron.png",
     rgb: "183, 62, 49",
   },

--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -47,6 +47,7 @@ export const DEFAULT_TEST_CHAINS = [
   "near:testnet",
   "mvx:D",
   "tron:0xcd8690dc",
+  "tron:0x94a9059e",
   "tezos:testnet",
   "kadena:testnet04",
   "bip122:000000000933ea01ad0ee984209779ba",

--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -126,7 +126,11 @@ import {
   getNamespacedDidChainId,
 } from "@walletconnect/utils";
 import { BIP122_DUST_LIMIT } from "../chains/bip122";
-import { getTronWeb } from "../helpers/tron";
+import {
+  getTronWeb,
+  TRON_MAINNET_USDT_CONTRACT,
+  TRON_TEST_CONTRACTS,
+} from "../helpers/tron";
 import { verifyTonProofSignature, verifyTonSignData } from "../helpers/ton";
 /**
  * Types
@@ -1852,13 +1856,12 @@ export function JsonRpcContextProvider({
           throw new Error("TronWeb not found for chainId: " + chainId);
         }
 
-        // Take USDT as an example:
-        // Nile TestNet: https://nile.tronscan.org/#/token20/TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf
-        // MainNet: https://tronscan.org/#/token20/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
-
         const testContract = isTestnet
-          ? "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
-          : "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+          ? TRON_TEST_CONTRACTS[chainId]
+          : TRON_MAINNET_USDT_CONTRACT;
+        if (!testContract) {
+          throw new Error("No TRON test contract configured for chainId: " + chainId);
+        }
         const { transaction } =
           await tronWeb.transactionBuilder.triggerSmartContract(
             testContract,
@@ -1953,8 +1956,11 @@ export function JsonRpcContextProvider({
         }
 
         const testContract = isTestnet
-          ? "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
-          : "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+          ? TRON_TEST_CONTRACTS[chainId]
+          : TRON_MAINNET_USDT_CONTRACT;
+        if (!testContract) {
+          throw new Error("No TRON test contract configured for chainId: " + chainId);
+        }
         const { transaction } =
           await tronWeb.transactionBuilder.triggerSmartContract(
             testContract,

--- a/advanced/dapps/react-dapp-v2/src/helpers/tron.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/tron.ts
@@ -22,7 +22,7 @@ export const getTronWeb = (network: string) => {
   if (network === "tron:0x94a9059e") {
     if (!tronWebShasta) {
       tronWebShasta = new TronWeb({
-        fullHost: "https://api.shasta.trongrid.io",
+        fullHost: "https://api.shasta.trongrid.io/",
       });
     }
     return tronWebShasta;

--- a/advanced/dapps/react-dapp-v2/src/helpers/tron.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/tron.ts
@@ -1,14 +1,31 @@
 import { TronWeb } from "tronweb";
 let tronWebMainnet: TronWeb;
-let tronWebTestnet: TronWeb;
+let tronWebNile: TronWeb;
+let tronWebShasta: TronWeb;
+
+export const TRON_TEST_CONTRACTS: Record<string, string> = {
+  "tron:0xcd8690dc": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+  "tron:0x94a9059e": "TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs",
+};
+
+export const TRON_MAINNET_USDT_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
 export const getTronWeb = (network: string) => {
   if (network === "tron:0xcd8690dc") {
-    if (!tronWebTestnet) {
-      tronWebTestnet = new TronWeb({
+    if (!tronWebNile) {
+      tronWebNile = new TronWeb({
         fullHost: "https://nile.trongrid.io/",
       });
     }
-    return tronWebTestnet;
+    return tronWebNile;
+  }
+  if (network === "tron:0x94a9059e") {
+    if (!tronWebShasta) {
+      tronWebShasta = new TronWeb({
+        fullHost: "https://api.shasta.trongrid.io",
+      });
+    }
+    return tronWebShasta;
   }
   if (network === "tron:0x2b6653dc") {
     if (!tronWebMainnet) {

--- a/advanced/wallets/react-wallet-v2/src/data/TronData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/TronData.ts
@@ -1,7 +1,7 @@
 /**
  * Types
  */
-export type TTronChain = keyof typeof TRON_MAINNET_CHAINS
+export type TTronChain = keyof typeof TRON_CHAINS
 
 interface TRONChains {
   [key: string]: ChainMetadata

--- a/advanced/wallets/react-wallet-v2/src/data/TronData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/TronData.ts
@@ -41,6 +41,15 @@ export const TRON_TEST_CHAINS: TRONChains = {
     fullNode: 'https://nile.trongrid.io/',
     namespace: 'tron',
     symbol: 'TRX'
+  },
+  'tron:0x94a9059e': {
+    chainId: '0x94a9059e',
+    name: 'TRON Shasta Testnet',
+    logo: 'chain-logos/tron.png',
+    rgb: '183, 62, 49',
+    fullNode: 'https://api.shasta.trongrid.io',
+    namespace: 'tron',
+    symbol: 'TRX'
   }
 }
 


### PR DESCRIPTION
## Summary
- Add TRON Shasta to the React dapp and wallet testnet configuration.
- Route Shasta requests through its TronGrid endpoint.
- Use chain-specific TRC-20 demo contracts for Nile and Shasta.

## Validation
- git diff --check
- React dapp production build