### PR TITLE
feat(react-wallet-v2): add query-driven ERC-20 send page

### DIFF
--- a/advanced/wallets/react-wallet-v2/README.md
+++ b/advanced/wallets/react-wallet-v2/README.md
@@ -74,17 +74,19 @@ url: `/walletconnect`
 url: `/send`
 
 Self-initiated ERC-20 transfer from the active EOA. Prefilled from the query string, so a test can
-drive it deterministically:
+drive it deterministically. `e2e_encrypted` is the same page-load wallet seed used everywhere else
+(see `scripts/encrypt-mnemonic.js`); without it `to`, `amount` and `auto` are ignored:
 
-`/send?chain=eip155:8453&token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x...&amount=1&auto=1`
+`/send?e2e_encrypted=<encrypted_mnemonic>&chain=eip155:8453&token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x000000000000000000000000000000000000dEaD&amount=1&auto=1`
 
 | Param | Description |
 | ----------- | ----------- |
 | `chain` | CAIP-2 chain id, e.g. `eip155:8453` (mainnets only) |
 | `token` | ERC-20 contract address, must be a token known for that chain |
-| `to` | Recipient address |
-| `amount` | Amount in human units, e.g. `1.5` |
-| `auto` | `1` submits automatically once the wallet is initialised and the inputs are valid. Only honoured when the wallet was seeded from `e2e_encrypted` in the same page load, so a link can never spend a locally stored wallet |
+| `e2e_encrypted` | Encrypted mnemonic that seeds the wallet for this page load. Required for `to`, `amount` and `auto` to take effect |
+| `to` | Recipient address (checksummed or all-lowercase). Only prefilled for an `e2e_encrypted` wallet |
+| `amount` | Amount in human units, e.g. `1.5`, with at most the token's decimals. Only prefilled for an `e2e_encrypted` wallet |
+| `auto` | `1` submits automatically once the wallet is initialised and the inputs are valid. Only honoured for an `e2e_encrypted` wallet, so a link can never spend a locally stored wallet |
 
 | Key | Description |
 | ----------- | ----------- |

--- a/advanced/wallets/react-wallet-v2/README.md
+++ b/advanced/wallets/react-wallet-v2/README.md
@@ -58,7 +58,6 @@ Accessible with `data-testid`
 | ----------- | ----------- |
 |  `accounts` | Accounts page |
 | `sessions` | Sessions page |
-| `send` | Send page |
 | `wc-connect` |  WC Connect page |
 | `pairings` | Pairings page |
 | `settings` | Settings Page |

--- a/advanced/wallets/react-wallet-v2/README.md
+++ b/advanced/wallets/react-wallet-v2/README.md
@@ -58,6 +58,7 @@ Accessible with `data-testid`
 | ----------- | ----------- |
 |  `accounts` | Accounts page |
 | `sessions` | Sessions page |
+| `send` | Send page |
 | `wc-connect` |  WC Connect page |
 | `pairings` | Pairings page |
 | `settings` | Settings Page |
@@ -69,6 +70,32 @@ url: `/walletconnect`
 | `uri-input` | Uri textbox |
 | `uri-connect-button` | Uri connect button |
 | `qrcode-button` | Use qrcode button | 
+
+### Send Page
+url: `/send`
+
+Self-initiated ERC-20 transfer from the active EOA. Prefilled from the query string, so a test can
+drive it deterministically:
+
+`/send?chain=eip155:8453&token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x...&amount=1&auto=1`
+
+| Param | Description |
+| ----------- | ----------- |
+| `chain` | CAIP-2 chain id, e.g. `eip155:8453` (mainnets only) |
+| `token` | ERC-20 contract address, must be a token known for that chain |
+| `to` | Recipient address |
+| `amount` | Amount in human units, e.g. `1.5` |
+| `auto` | `1` submits automatically once the wallet is initialised and the inputs are valid |
+
+| Key | Description |
+| ----------- | ----------- |
+| `send-chain-select` | Chain drop down selector |
+| `send-token-select` | Token drop down selector |
+| `send-to-input` | Recipient textbox |
+| `send-amount-input` | Amount textbox |
+| `send-submit-button` | Send button |
+| `send-tx-hash` | Broadcast transaction hash |
+| `send-error` | Error message |
 
 ### Sessions Page
 url: `/session`

--- a/advanced/wallets/react-wallet-v2/README.md
+++ b/advanced/wallets/react-wallet-v2/README.md
@@ -85,7 +85,7 @@ drive it deterministically:
 | `token` | ERC-20 contract address, must be a token known for that chain |
 | `to` | Recipient address |
 | `amount` | Amount in human units, e.g. `1.5` |
-| `auto` | `1` submits automatically once the wallet is initialised and the inputs are valid |
+| `auto` | `1` submits automatically once the wallet is initialised and the inputs are valid. Only honoured when the wallet was seeded from `e2e_encrypted` in the same page load, so a link can never spend a locally stored wallet |
 
 | Key | Description |
 | ----------- | ----------- |

--- a/advanced/wallets/react-wallet-v2/package.json
+++ b/advanced/wallets/react-wallet-v2/package.json
@@ -9,6 +9,7 @@
     "prettier": "prettier --check '**/*.{js,ts,jsx,tsx}'",
     "prettier:write": "prettier --write '**/*.{js,ts,jsx,tsx}'",
     "test:e2e-derivation": "node scripts/test-solana-e2e-derivation.js",
+    "test:erc20-amount": "node scripts/test-erc20-amount.js",
     "test:stellar-sep53": "node scripts/test-stellar-sep53.js"
   },
   "dependencies": {

--- a/advanced/wallets/react-wallet-v2/scripts/test-erc20-amount.js
+++ b/advanced/wallets/react-wallet-v2/scripts/test-erc20-amount.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/**
+ * ERC-20 send amount validation (src/utils/Erc20AmountUtil.ts).
+ *
+ * The module is transpiled on the fly so the cases below run against the real
+ * implementation rather than a copy. The rounding cases matter most: viem's
+ * `parseUnits` silently rounds fractional digits beyond the token's decimals, so
+ * `1.0000005` USDC would otherwise leave the wallet as `1.000001`.
+ */
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ts = require('typescript')
+
+function loadAmountUtil() {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'utils', 'Erc20AmountUtil.ts'),
+    'utf-8'
+  )
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+  })
+  const module = { exports: {} }
+  new Function('require', 'module', 'exports', outputText)(require, module, module.exports)
+
+  return module.exports
+}
+
+const { getAmountError, parseErc20Amount } = loadAmountUtil()
+
+// [amount, decimals, expected base units]
+const ACCEPTED = [
+  ['1', 6, 1000000n],
+  ['1.5', 6, 1500000n],
+  ['0.000001', 6, 1n],
+  ['1.000001', 6, 1000001n],
+  ['123456789.123456789012345678', 18, 123456789123456789012345678n],
+  ['1', 0, 1n]
+]
+
+// [amount, decimals, substring the error must contain]
+const REJECTED = [
+  ['1.0000005', 6, 'decimal places'],
+  ['0.0000001', 6, 'decimal places'],
+  ['0.5', 0, 'decimal places'],
+  ['1.1234567890123456789', 18, 'decimal places'],
+  ['0', 6, 'greater than zero'],
+  ['0.0', 6, 'greater than zero'],
+  ['0.000000', 6, 'greater than zero'],
+  ['', 6, 'Invalid amount'],
+  ['.5', 6, 'Invalid amount'],
+  ['1.', 6, 'Invalid amount'],
+  ['-1', 6, 'Invalid amount'],
+  ['1e6', 6, 'Invalid amount'],
+  ['1,5', 6, 'Invalid amount'],
+  [' 1', 6, 'Invalid amount'],
+  ['0x10', 6, 'Invalid amount']
+]
+
+for (const [amount, decimals, expected] of ACCEPTED) {
+  const label = `${JSON.stringify(amount)} with ${decimals} decimals`
+
+  assert.equal(getAmountError(amount, decimals), undefined, `${label} should be accepted`)
+  assert.equal(parseErc20Amount(amount, decimals), expected, `${label} should parse exactly`)
+}
+
+for (const [amount, decimals, fragment] of REJECTED) {
+  const label = `${JSON.stringify(amount)} with ${decimals} decimals`
+  const error = getAmountError(amount, decimals)
+
+  assert.ok(error, `${label} should be rejected`)
+  assert.match(error, new RegExp(fragment), `${label} should explain why`)
+  assert.throws(
+    () => parseErc20Amount(amount, decimals),
+    new RegExp(fragment),
+    `${label} should throw`
+  )
+}
+
+console.log(
+  `ERC-20 amount validation: ${ACCEPTED.length} accepted + ${REJECTED.length} rejected cases passed`
+)

--- a/advanced/wallets/react-wallet-v2/src/components/Navigation.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/Navigation.tsx
@@ -13,6 +13,10 @@ export default function Navigation() {
         <Image alt="sessions icon" src="/icons/sessions-icon.svg" width={27} height={27} />
       </Link>
 
+      <Link href="/send" passHref className="navLink" data-testid="send">
+        <Image alt="send icon" src="/icons/arrow-right-icon.svg" width={27} height={27} />
+      </Link>
+
       <Link href="/walletconnect" passHref className="navLink" data-testid="wc-connect">
         <Avatar
           size="lg"

--- a/advanced/wallets/react-wallet-v2/src/components/Navigation.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/Navigation.tsx
@@ -13,10 +13,6 @@ export default function Navigation() {
         <Image alt="sessions icon" src="/icons/sessions-icon.svg" width={27} height={27} />
       </Link>
 
-      <Link href="/send" passHref className="navLink" data-testid="send">
-        <Image alt="send icon" src="/icons/arrow-right-icon.svg" width={27} height={27} />
-      </Link>
-
       <Link href="/walletconnect" passHref className="navLink" data-testid="wc-connect">
         <Avatar
           size="lg"

--- a/advanced/wallets/react-wallet-v2/src/pages/send.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/send.tsx
@@ -58,11 +58,15 @@ export default function SendPage() {
      chain simply falls through. */
   const queryToken = readQueryParam(query.token)
   const token = useMemo(() => {
-    const candidate = [pickedToken, queryToken].find(
-      value => value && tokens.some(option => option.address.toLowerCase() === value.toLowerCase())
-    )
+    // Match case-insensitively but return the catalog's address, so the `===`
+    // lookups below (decimals, dropdown value) see the canonical form.
+    for (const value of [pickedToken, queryToken]) {
+      if (!value) continue
+      const match = tokens.find(option => option.address.toLowerCase() === value.toLowerCase())
+      if (match) return match.address
+    }
 
-    return candidate ?? tokens[0]?.address ?? ''
+    return tokens[0]?.address ?? ''
   }, [pickedToken, queryToken, tokens])
 
   const decimals = tokens.find(option => option.address === token)?.decimals ?? 0

--- a/advanced/wallets/react-wallet-v2/src/pages/send.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/send.tsx
@@ -1,0 +1,198 @@
+import PageHeader from '@/components/PageHeader'
+import StyledDivider from '@/components/StyledDivider'
+import { EIP155_MAINNET_CHAINS } from '@/data/EIP155Data'
+import SettingsStore from '@/store/SettingsStore'
+import { getErc20TokensForChain, sendErc20 } from '@/utils/EIP155SendUtil'
+import { Button, Input, Loading, Row, Text } from '@nextui-org/react'
+import { useRouter } from 'next/router'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSnapshot } from 'valtio'
+import { isAddress } from 'viem'
+
+const DEFAULT_CHAIN_ID = 'eip155:8453'
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
+
+function readQueryParam(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+export default function SendPage() {
+  const { eip155Address } = useSnapshot(SettingsStore.state)
+  const { query, isReady } = useRouter()
+
+  const [chainId, setChainId] = useState(DEFAULT_CHAIN_ID)
+  const [token, setToken] = useState('')
+  const [to, setTo] = useState('')
+  const [amount, setAmount] = useState('')
+  const [txHash, setTxHash] = useState('')
+  const [error, setError] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const autoSubmitted = useRef(false)
+
+  const tokens = useMemo(() => getErc20TokensForChain(chainId), [chainId])
+  const initialized = Boolean(eip155Address)
+  const autoSubmit = readQueryParam(query.auto) === '1'
+
+  const inputsValid =
+    Boolean(token) && isAddress(to) && AMOUNT_PATTERN.test(amount) && parseFloat(amount) > 0
+  const canSubmit = initialized && inputsValid && !sending
+
+  // Prefill once the router has parsed the query string.
+  useEffect(() => {
+    if (!isReady) return
+
+    const chainParam = readQueryParam(query.chain)
+    if (chainParam && EIP155_MAINNET_CHAINS[chainParam]) {
+      setChainId(chainParam)
+    }
+
+    const tokenParam = readQueryParam(query.token)
+    if (tokenParam) {
+      setToken(tokenParam)
+    }
+
+    const toParam = readQueryParam(query.to)
+    if (toParam) {
+      setTo(toParam)
+    }
+
+    const amountParam = readQueryParam(query.amount)
+    if (amountParam) {
+      setAmount(amountParam)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady])
+
+  /* Keep the token selection consistent with the chain: a token prefilled for
+     another chain (or none at all) falls back to the chain's first token. */
+  useEffect(() => {
+    const isKnownToken = tokens.some(option => option.address.toLowerCase() === token.toLowerCase())
+    if (!isKnownToken) {
+      setToken(tokens[0]?.address ?? '')
+    }
+  }, [tokens, token])
+
+  const onSend = useCallback(async () => {
+    setSending(true)
+    setError('')
+    setTxHash('')
+    try {
+      const { hash } = await sendErc20({ chainId, token, to, amount })
+      setTxHash(hash)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSending(false)
+    }
+  }, [chainId, token, to, amount])
+
+  useEffect(() => {
+    if (!autoSubmit || autoSubmitted.current || !canSubmit) return
+    autoSubmitted.current = true
+    onSend()
+  }, [autoSubmit, canSubmit, onSend])
+
+  return (
+    <Fragment>
+      <PageHeader title="Send" />
+
+      <Text h4 css={{ marginBottom: '$5' }}>
+        Chain
+      </Text>
+      <select
+        value={chainId}
+        onChange={e => setChainId(e.currentTarget.value)}
+        disabled={!initialized || sending}
+        aria-label="send chain"
+        data-testid="send-chain-select"
+      >
+        {Object.entries(EIP155_MAINNET_CHAINS).map(([caip2, chain]) => (
+          <option key={caip2} value={caip2}>
+            {chain.name}
+          </option>
+        ))}
+      </select>
+
+      <StyledDivider css={{ my: '$8' }} />
+
+      <Text h4 css={{ marginBottom: '$5' }}>
+        Token
+      </Text>
+      {tokens.length ? (
+        <select
+          value={token}
+          onChange={e => setToken(e.currentTarget.value)}
+          disabled={!initialized || sending}
+          aria-label="send token"
+          data-testid="send-token-select"
+        >
+          {tokens.map(option => (
+            <option key={option.address} value={option.address}>
+              {option.symbol}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <Text color="$gray400">No known ERC-20 tokens on this chain</Text>
+      )}
+
+      <StyledDivider css={{ my: '$8' }} />
+
+      <Input
+        css={{ width: '100%', marginBottom: '$8' }}
+        bordered
+        label="Recipient"
+        aria-label="send recipient input"
+        placeholder="0x..."
+        value={to}
+        disabled={!initialized || sending}
+        onChange={e => setTo(e.target.value)}
+        data-testid="send-to-input"
+      />
+
+      <Input
+        css={{ width: '100%', marginBottom: '$8' }}
+        bordered
+        label="Amount"
+        aria-label="send amount input"
+        placeholder="e.g. 1.5"
+        value={amount}
+        disabled={!initialized || sending}
+        onChange={e => setAmount(e.target.value)}
+        data-testid="send-amount-input"
+      />
+
+      <Row justify="center">
+        <Button
+          color="gradient"
+          disabled={!canSubmit}
+          onClick={onSend}
+          data-testid="send-submit-button"
+        >
+          {sending ? <Loading size="sm" type="points" color="white" /> : 'Send'}
+        </Button>
+      </Row>
+
+      {txHash ? (
+        <Text
+          css={{ marginTop: '$10', wordBreak: 'break-all' }}
+          color="success"
+          data-testid="send-tx-hash"
+        >
+          {txHash}
+        </Text>
+      ) : null}
+
+      {error ? (
+        <Text
+          css={{ marginTop: '$10', wordBreak: 'break-all' }}
+          color="error"
+          data-testid="send-error"
+        >
+          {error}
+        </Text>
+      ) : null}
+    </Fragment>
+  )
+}

--- a/advanced/wallets/react-wallet-v2/src/pages/send.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/send.tsx
@@ -2,7 +2,8 @@ import PageHeader from '@/components/PageHeader'
 import StyledDivider from '@/components/StyledDivider'
 import { EIP155_MAINNET_CHAINS } from '@/data/EIP155Data'
 import SettingsStore from '@/store/SettingsStore'
-import { getErc20TokensForChain, sendErc20 } from '@/utils/EIP155SendUtil'
+import { AMOUNT_PATTERN, getErc20TokensForChain, sendErc20 } from '@/utils/EIP155SendUtil'
+import { isE2ESeededWallet } from '@/utils/EIP155WalletUtil'
 import { Button, Input, Loading, Row, Text } from '@nextui-org/react'
 import { useRouter } from 'next/router'
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -10,7 +11,6 @@ import { useSnapshot } from 'valtio'
 import { isAddress } from 'viem'
 
 const DEFAULT_CHAIN_ID = 'eip155:8453'
-const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
 
 function readQueryParam(value: string | string[] | undefined): string | undefined {
   return typeof value === 'string' ? value : undefined
@@ -32,10 +32,15 @@ export default function SendPage() {
 
   const tokens = useMemo(() => getErc20TokensForChain(chainId), [chainId])
   const initialized = Boolean(eip155Address)
-  const autoSubmit = readQueryParam(query.auto) === '1'
+  const tokenKnown = tokens.some(option => option.address.toLowerCase() === token.toLowerCase())
+
+  /* Unattended submits are for the E2E wallet only: this is a public demo wallet
+     where people import their own mnemonic, and a crafted `?auto=1` link would
+     otherwise drain them without a single click. */
+  const autoSubmit = readQueryParam(query.auto) === '1' && isE2ESeededWallet()
 
   const inputsValid =
-    Boolean(token) && isAddress(to) && AMOUNT_PATTERN.test(amount) && parseFloat(amount) > 0
+    tokenKnown && isAddress(to) && AMOUNT_PATTERN.test(amount) && parseFloat(amount) > 0
   const canSubmit = initialized && inputsValid && !sending
 
   // Prefill once the router has parsed the query string.
@@ -67,11 +72,10 @@ export default function SendPage() {
   /* Keep the token selection consistent with the chain: a token prefilled for
      another chain (or none at all) falls back to the chain's first token. */
   useEffect(() => {
-    const isKnownToken = tokens.some(option => option.address.toLowerCase() === token.toLowerCase())
-    if (!isKnownToken) {
+    if (!tokenKnown) {
       setToken(tokens[0]?.address ?? '')
     }
-  }, [tokens, token])
+  }, [tokens, tokenKnown])
 
   const onSend = useCallback(async () => {
     setSending(true)

--- a/advanced/wallets/react-wallet-v2/src/pages/send.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/send.tsx
@@ -2,8 +2,9 @@ import PageHeader from '@/components/PageHeader'
 import StyledDivider from '@/components/StyledDivider'
 import { EIP155_MAINNET_CHAINS } from '@/data/EIP155Data'
 import SettingsStore from '@/store/SettingsStore'
-import { AMOUNT_PATTERN, getErc20TokensForChain, sendErc20 } from '@/utils/EIP155SendUtil'
+import { getErc20TokensForChain, sendErc20 } from '@/utils/EIP155SendUtil'
 import { isE2ESeededWallet } from '@/utils/EIP155WalletUtil'
+import { getAmountError } from '@/utils/Erc20AmountUtil'
 import { Button, Input, Loading, Row, Text } from '@nextui-org/react'
 import { useRouter } from 'next/router'
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -11,9 +12,19 @@ import { useSnapshot } from 'valtio'
 import { isAddress } from 'viem'
 
 const DEFAULT_CHAIN_ID = 'eip155:8453'
+const HEX_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
 
 function readQueryParam(value: string | string[] | undefined): string | undefined {
   return typeof value === 'string' ? value : undefined
+}
+
+function getRecipientError(to: string): string | undefined {
+  if (!to || isAddress(to)) return undefined
+  if (HEX_ADDRESS_PATTERN.test(to)) {
+    return 'Recipient address has an invalid checksum: use all-lowercase or the EIP-55 form'
+  }
+
+  return 'Invalid recipient address'
 }
 
 export default function SendPage() {
@@ -21,7 +32,8 @@ export default function SendPage() {
   const { query, isReady } = useRouter()
 
   const [chainId, setChainId] = useState(DEFAULT_CHAIN_ID)
-  const [token, setToken] = useState('')
+  // Token picked in the dropdown; empty until the user changes it.
+  const [pickedToken, setPickedToken] = useState('')
   const [to, setTo] = useState('')
   const [amount, setAmount] = useState('')
   const [txHash, setTxHash] = useState('')
@@ -29,33 +41,49 @@ export default function SendPage() {
   const [sending, setSending] = useState(false)
 
   const autoSubmitted = useRef(false)
+  const prefilled = useRef(false)
 
   const tokens = useMemo(() => getErc20TokensForChain(chainId), [chainId])
   const initialized = Boolean(eip155Address)
-  const tokenKnown = tokens.some(option => option.address.toLowerCase() === token.toLowerCase())
 
-  /* Unattended submits are for the E2E wallet only: this is a public demo wallet
-     where people import their own mnemonic, and a crafted `?auto=1` link would
-     otherwise drain them without a single click. */
-  const autoSubmit = readQueryParam(query.auto) === '1' && isE2ESeededWallet()
+  /* The query only prefills the wallet the E2E harness seeded from `e2e_encrypted`:
+     this is a public demo wallet where people import their own mnemonic, and a
+     crafted link must never hand them a one-click (or `?auto=1`, zero-click)
+     transfer to an attacker's address. */
+  const e2eSeeded = initialized && isE2ESeededWallet()
+  const autoSubmit = readQueryParam(query.auto) === '1' && e2eSeeded
+
+  /* Derived rather than synced through effects: the dropdown pick wins, then the
+     query token, then the chain's first token. A prefilled token from another
+     chain simply falls through. */
+  const queryToken = readQueryParam(query.token)
+  const token = useMemo(() => {
+    const candidate = [pickedToken, queryToken].find(
+      value => value && tokens.some(option => option.address.toLowerCase() === value.toLowerCase())
+    )
+
+    return candidate ?? tokens[0]?.address ?? ''
+  }, [pickedToken, queryToken, tokens])
+
+  const decimals = tokens.find(option => option.address === token)?.decimals ?? 0
+  const recipientError = getRecipientError(to)
+  const amountError = amount ? getAmountError(amount, decimals) : undefined
 
   const inputsValid =
-    tokenKnown && isAddress(to) && AMOUNT_PATTERN.test(amount) && parseFloat(amount) > 0
+    Boolean(token) && Boolean(to) && Boolean(amount) && !recipientError && !amountError
   const canSubmit = initialized && inputsValid && !sending
 
-  // Prefill once the router has parsed the query string.
+  // Prefill once the router has parsed the query string and the wallet is known.
   useEffect(() => {
-    if (!isReady) return
+    if (!isReady || !initialized || prefilled.current) return
+    prefilled.current = true
 
     const chainParam = readQueryParam(query.chain)
     if (chainParam && EIP155_MAINNET_CHAINS[chainParam]) {
       setChainId(chainParam)
     }
 
-    const tokenParam = readQueryParam(query.token)
-    if (tokenParam) {
-      setToken(tokenParam)
-    }
+    if (!e2eSeeded) return
 
     const toParam = readQueryParam(query.to)
     if (toParam) {
@@ -67,15 +95,7 @@ export default function SendPage() {
       setAmount(amountParam)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isReady])
-
-  /* Keep the token selection consistent with the chain: a token prefilled for
-     another chain (or none at all) falls back to the chain's first token. */
-  useEffect(() => {
-    if (!tokenKnown) {
-      setToken(tokens[0]?.address ?? '')
-    }
-  }, [tokens, tokenKnown])
+  }, [isReady, initialized])
 
   const onSend = useCallback(async () => {
     setSending(true)
@@ -126,7 +146,7 @@ export default function SendPage() {
       {tokens.length ? (
         <select
           value={token}
-          onChange={e => setToken(e.currentTarget.value)}
+          onChange={e => setPickedToken(e.currentTarget.value)}
           disabled={!initialized || sending}
           aria-label="send token"
           data-testid="send-token-select"
@@ -188,13 +208,13 @@ export default function SendPage() {
         </Text>
       ) : null}
 
-      {error ? (
+      {error || recipientError || amountError ? (
         <Text
           css={{ marginTop: '$10', wordBreak: 'break-all' }}
           color="error"
           data-testid="send-error"
         >
-          {error}
+          {error || recipientError || amountError}
         </Text>
       ) : null}
     </Fragment>

--- a/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/BalanceUtil.ts
@@ -22,14 +22,14 @@ interface ChainDataWithRpc {
   symbol?: string
 }
 
-interface TokenConfig {
+export interface TokenConfig {
   symbol: string
   decimals: number
   icon: string
   addresses: Record<number, string>
 }
 
-const TOKEN_CONFIGS: TokenConfig[] = [
+export const TOKEN_CONFIGS: TokenConfig[] = [
   {
     symbol: 'USDC',
     decimals: 6,

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
@@ -1,0 +1,110 @@
+import { EIP155_CHAINS, TEIP155Chain } from '@/data/EIP155Data'
+import SettingsStore from '@/store/SettingsStore'
+import { TOKEN_CONFIGS } from '@/utils/BalanceUtil'
+import { eip155Wallets } from '@/utils/EIP155WalletUtil'
+import { providers } from 'ethers'
+import { encodeFunctionData, erc20Abi, isAddress, parseUnits } from 'viem'
+
+export interface Erc20TokenOption {
+  address: string
+  symbol: string
+  decimals: number
+}
+
+export interface SendErc20Args {
+  /** CAIP-2 chain id, e.g. `eip155:8453` */
+  chainId: string
+  /** ERC-20 contract address */
+  token: string
+  /** Recipient address */
+  to: string
+  /** Amount in human units, e.g. `1.5` */
+  amount: string
+}
+
+export interface SendErc20Result {
+  hash: string
+}
+
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
+
+/**
+ * ERC-20 tokens this wallet knows how to send on a given chain. Derived from the
+ * balance overview config so the send screen can never offer a token the wallet
+ * cannot display.
+ */
+export function getErc20TokensForChain(chainId: string): Erc20TokenOption[] {
+  const numericChainId = Number(chainId.split(':')[1])
+  if (!Number.isFinite(numericChainId)) {
+    return []
+  }
+
+  return TOKEN_CONFIGS.filter(token => Boolean(token.addresses[numericChainId])).map(token => ({
+    address: token.addresses[numericChainId],
+    symbol: token.symbol,
+    decimals: token.decimals
+  }))
+}
+
+function findToken(chainId: string, token: string): Erc20TokenOption | undefined {
+  return getErc20TokensForChain(chainId).find(
+    option => option.address.toLowerCase() === token.toLowerCase()
+  )
+}
+
+/**
+ * Transfer an ERC-20 token from the active EOA to an arbitrary address.
+ * Resolves as soon as the transaction is broadcast - callers that need
+ * confirmation should poll the hash themselves.
+ */
+export async function sendErc20({
+  chainId,
+  token,
+  to,
+  amount
+}: SendErc20Args): Promise<SendErc20Result> {
+  const chain = EIP155_CHAINS[chainId as TEIP155Chain]
+  if (!chain) {
+    throw new Error(`Unsupported chain: ${chainId}`)
+  }
+
+  const tokenOption = findToken(chainId, token)
+  if (!tokenOption) {
+    throw new Error(`Unsupported token ${token} on ${chainId}`)
+  }
+
+  if (!isAddress(to)) {
+    throw new Error(`Invalid recipient address: ${to}`)
+  }
+
+  if (!AMOUNT_PATTERN.test(amount)) {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+
+  const value = parseUnits(amount, tokenOption.decimals)
+  if (value <= BigInt(0)) {
+    throw new Error('Amount must be greater than zero')
+  }
+
+  const { eip155Address } = SettingsStore.state
+  const wallet = eip155Wallets[eip155Address]
+  if (!wallet) {
+    throw new Error('Wallet is not initialized')
+  }
+
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [to as `0x${string}`, value]
+  })
+
+  const provider = new providers.JsonRpcProvider(chain.rpc)
+  const connectedWallet = wallet.connect(provider)
+  const txResponse = await connectedWallet.sendTransaction({
+    to: tokenOption.address,
+    value: '0x0',
+    data
+  })
+
+  return { hash: txResponse.hash }
+}

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
@@ -2,8 +2,9 @@ import { EIP155_CHAINS, TEIP155Chain } from '@/data/EIP155Data'
 import SettingsStore from '@/store/SettingsStore'
 import { TOKEN_CONFIGS } from '@/utils/BalanceUtil'
 import { eip155Wallets } from '@/utils/EIP155WalletUtil'
+import { parseErc20Amount } from '@/utils/Erc20AmountUtil'
 import { providers } from 'ethers'
-import { encodeFunctionData, erc20Abi, isAddress, parseUnits } from 'viem'
+import { encodeFunctionData, erc20Abi, isAddress } from 'viem'
 
 export interface Erc20TokenOption {
   address: string
@@ -25,9 +26,6 @@ export interface SendErc20Args {
 export interface SendErc20Result {
   hash: string
 }
-
-/** Amount in human units, e.g. `1` or `1.5` */
-export const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
 
 /**
  * ERC-20 tokens this wallet knows how to send on a given chain. Derived from the
@@ -78,14 +76,7 @@ export async function sendErc20({
     throw new Error(`Invalid recipient address: ${to}`)
   }
 
-  if (!AMOUNT_PATTERN.test(amount)) {
-    throw new Error(`Invalid amount: ${amount}`)
-  }
-
-  const value = parseUnits(amount, tokenOption.decimals)
-  if (value <= BigInt(0)) {
-    throw new Error('Amount must be greater than zero')
-  }
+  const value = parseErc20Amount(amount, tokenOption.decimals)
 
   const { eip155Address } = SettingsStore.state
   const wallet = eip155Wallets[eip155Address]

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155SendUtil.ts
@@ -26,7 +26,8 @@ export interface SendErc20Result {
   hash: string
 }
 
-const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
+/** Amount in human units, e.g. `1` or `1.5` */
+export const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
 
 /**
  * ERC-20 tokens this wallet knows how to send on a given chain. Derived from the

--- a/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/EIP155WalletUtil.ts
@@ -9,6 +9,16 @@ export let eip155Addresses: string[] = []
 
 let address1: string
 let address2: string
+let e2eSeeded = false
+
+/**
+ * Whether the active EIP155 wallet was seeded from `?e2e_encrypted=` in this page
+ * load, rather than restored from localStorage. Guards unattended actions that
+ * must never run against a wallet holding a real user's funds.
+ */
+export function isE2ESeededWallet(): boolean {
+  return e2eSeeded
+}
 
 /**
  * Fetch E2E credentials (async, called before wallet init)
@@ -61,6 +71,8 @@ export async function fetchE2ECredentials(): Promise<string | undefined> {
  * Utilities
  */
 export function createOrRestoreEIP155Wallet({ mnemonic }: { mnemonic?: string } = {}) {
+  e2eSeeded = Boolean(mnemonic)
+
   if (mnemonic) {
     // Remove credentials persisted by the legacy E2E handoff.
     localStorage.removeItem('E2E_MNEMONIC')

--- a/advanced/wallets/react-wallet-v2/src/utils/Erc20AmountUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/Erc20AmountUtil.ts
@@ -1,0 +1,38 @@
+import { parseUnits } from 'viem'
+
+/** Amount in human units, e.g. `1` or `1.5` */
+export const AMOUNT_PATTERN = /^\d+(\.\d+)?$/
+
+/**
+ * Why a human-readable amount cannot be sent for a token with `decimals`, or
+ * `undefined` when it can. Kept free of app imports so `scripts/test-erc20-amount.js`
+ * can load it directly.
+ */
+export function getAmountError(amount: string, decimals: number): string | undefined {
+  if (!AMOUNT_PATTERN.test(amount)) {
+    return `Invalid amount: ${amount}`
+  }
+
+  /* parseUnits silently rounds extra fractional digits (1.0000005 USDC would be
+     sent as 1.000001), so reject them instead of moving money the user did not type. */
+  const fraction = amount.split('.')[1] ?? ''
+  if (fraction.length > decimals) {
+    return `Amount has ${fraction.length} decimal places, token supports at most ${decimals}`
+  }
+
+  if (!/[1-9]/.test(amount)) {
+    return 'Amount must be greater than zero'
+  }
+
+  return undefined
+}
+
+/** Parse a validated human-readable amount into base units. Throws on any validation error. */
+export function parseErc20Amount(amount: string, decimals: number): bigint {
+  const error = getAmountError(amount, decimals)
+  if (error) {
+    throw new Error(error)
+  }
+
+  return parseUnits(amount, decimals)
+}


### PR DESCRIPTION
Adds a self-initiated ERC-20 send screen at `/send`. Until now the wallet could only sign requests arriving over a WalletConnect session, so a WalletConnect Pay direct-deposit E2E test had no way to make it push USDC on its own. The new page resolves the active EOA, encodes an ERC-20 `transfer`, broadcasts it via the chain's RPC, and returns the hash as soon as it is sent. ERC-20 only — no native ETH, no smart accounts.

Drive it deterministically from the query string:

```
/send?chain=eip155:8453&token=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x...&amount=1&auto=1
```

`chain` is CAIP-2 (mainnets only), `token` must be a token known for that chain, `amount` is human units, and `auto=1` submits once the wallet is initialised and the inputs validate. New DOM test ids and the query params are documented in the README.

Verified with `tsc --noEmit` (clean), `pnpm build` (clean, `/send` in the route list), and a headless-browser load of the page against `next dev`: every `send-*` test id renders, the prefill lands in the right fields, and the submit button enables only once the inputs are valid. Nothing broadcasts unless the form is submitted, so no transaction was sent while testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)